### PR TITLE
Return to v5.8, since this is a prerequisite to HTML::HeadParser and LWP::UserAgent

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -90,6 +90,12 @@ jobs:
             - name: Setup environment
               run: |
                 echo "PERL_LWP_SSL_VERIFY_HOSTNAME=0" >> $GITHUB_ENV
+# Install this module locally so we don't get the CPAN version which
+# requires v5.10.
+            - name:
+              if: env.PERL_VERSION == 'v5.8'
+              run: |
+                cpan .
 # I had some problems with openssl on Ubuntu, so I punted by installing
 # cpanm first, which is easy. I can install IO::Socket::SSL with that,
 # then switch back to cpan. I didn't explore this further, but what you
@@ -98,7 +104,7 @@ jobs:
             - name: Install cpanm and multiple modules
               run: |
                 curl -L https://cpanmin.us | perl - App::cpanminus
-                cpanm --notest IO::Socket::SSL App::Cpan HTTP::Tiny ExtUtils::MakeMaker Test::Manifest Test::More
+                cpanm --notest IO::Socket::SSL LWP::Protocol::https App::Cpan HTTP::Tiny ExtUtils::MakeMaker Test::Manifest Test::More
 # Install the dependencies, again not testing them. This installs the
 # module in the current directory, so we end up installing the module,
 # but that's not a big deal.

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -1,131 +1,151 @@
-name: testsuite
+# brian's standard GitHub Actions Ubuntu config for Perl 5 modules
+# version 20240909.001
+# https://github.com/briandfoy/github_workflows
+# https://github.com/features/actions
+# This file is licensed under the Artistic License 2.0
+#
+# This uses the AUTOMATED_TESTING environment that you can set up
+# in your repo settings. Or not. It still works if it isn't defined.
+# In that environment, add whatever environment variables or secrets
+# that you want.
+---
+name: ubuntu
+
+# https://github.com/actions/checkout/issues/1590
+env:
+    ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-concurrency
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+    cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - "*"
-    tags-ignore:
-      - "*"
-  pull_request:
+    push:
+        branches:
+            - '**'
+            - '!**appveyor**'
+            - '!**circleci**'
+            - '!**macos**'
+            - '!**notest**'
+            - '!**release**'
+            - '!**windows**'
+        tags-ignore:
+            # I tag release pushes but those should have already been tested
+            - 'release-*'
+        paths-ignore:
+            # list all the files which are irrelevant to the tests
+            # non-code, support files, docs, etc
+            - '.appveyor.yml'
+            - '.circleci'
+            - '.gitattributes'
+            - '.github/workflows/macos.yml'
+            - '.github/workflows/release.yml'
+            - '.github/workflows/windows.yml'
+            - '.gitignore'
+            - '.releaserc'
+            - 'Changes'
+            - 'LICENSE'
+            - 'README.pod'
+    pull_request:
 
 jobs:
-  ubuntu:
-    env:
-      PERL_USE_UNSAFE_INC: 0
-      AUTHOR_TESTING: 1
-      AUTOMATED_TESTING: 1
-      RELEASE_TESTING: 1
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: perl -V
-        run: perl -V
-      - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@stable
-        with:
-          cpanfile: "cpanfile"
-      - name: Makefile.PL
-        run: perl -I$(pwd) Makefile.PL
-      - name: make test
-        run: make test
-
-  linux:
-    name: "linux ${{ matrix.perl-version }}"
-    needs: [ubuntu]
-    runs-on: ubuntu-latest
-
-    env:
-      PERL_USE_UNSAFE_INC: 0
-      AUTHOR_TESTING: 1
-      AUTOMATED_TESTING: 1
-      RELEASE_TESTING: 1
-      PERL_CARTON_PATH: $GITHUB_WORKSPACE/local
-
-    strategy:
-      matrix:
-        perl-version:
-          - "latest"
-          - "5.38"
-          - "5.36"
-          - "5.34"
-          - "5.32"
-          - "5.30"
-          - "5.28"
-          - "5.26"
-          - "5.24"
-          - "5.22"
-          - "5.20"
-          - "5.18"
-          - "5.16"
-          - "5.14"
-          - "5.12"
-          - "5.10"
-          - "5.8"
-
-    container:
-      image: perl:${{ matrix.perl-version }}
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: perl -V
-        run: perl -V
-      - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@stable
-        with:
-          sudo: false
-          cpanfile: "cpanfile"
-      - run: perl Makefile.PL
-      - run: make
-      - run: make test
-
-  macOS:
-    needs: [ubuntu, linux]
-    runs-on: macOS-latest
-
-    env:
-      PERL_USE_UNSAFE_INC: 0
-      AUTHOR_TESTING: 1
-      AUTOMATED_TESTING: 1
-      RELEASE_TESTING: 1
-      PERL_CARTON_PATH: $GITHUB_WORKSPACE/local
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Perl
-        run: brew install perl
-      - name: perl -V
-        run: perl -V
-      - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@stable
-        with:
-          sudo: false
-          cpanfile: "cpanfile"
-      - run: perl Makefile.PL
-      - run: make
-      - run: make test
-
-  windows:
-    needs: [ubuntu, linux]
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Perl
-        run: |
-          choco install strawberryperl
-          echo 'PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin' >> $GITHUB_ENV
-      - name: perl -V
-        run: perl -V
-      - name: Install Dependencies
-        uses: perl-actions/install-with-cpm@stable
-        with:
-          sudo: false
-          cpanfile: "cpanfile"
-      - name: perl Makefile.PL
-        run: perl Makefile.PL
-      - name: make
-        run: make
-      - name: Run Tests
-        run: make test
+    perl:
+        environment: automated_testing
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os:
+                    - ubuntu-22.04
+                perl-version:
+                    - '5.8-buster'
+                    - '5.10-buster'
+                    - '5.12-buster'
+                    - '5.14-buster'
+                    - '5.16-buster'
+                    - '5.18-buster'
+                    - '5.20-buster'
+                    - '5.22-buster'
+                    - '5.24-buster'
+                    - '5.26-buster'
+                    - '5.28-buster'
+                    - '5.30-bullseye'
+                    - '5.32-bullseye'
+                    - '5.34-bullseye'
+                    - '5.36-bookworm'
+                    - '5.38-bookworm'
+                    - 'latest'
+        container:
+            image: perl:${{ matrix.perl-version }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Platform check
+              run: uname -a
+            - name: Perl version check
+              run: |
+                perl -V
+                perl -v | perl -0777 -ne 'm/(v5\.\d+)/ && print "PERL_VERSION=$1"' >> $GITHUB_ENV
+# Some older versions of Perl have trouble with hostnames in certs. I
+# haven't figured out why.
+            - name: Setup environment
+              run: |
+                echo "PERL_LWP_SSL_VERIFY_HOSTNAME=0" >> $GITHUB_ENV
+# I had some problems with openssl on Ubuntu, so I punted by installing
+# cpanm first, which is easy. I can install IO::Socket::SSL with that,
+# then switch back to cpan. I didn't explore this further, but what you
+# see here hasn't caused problems for me.
+# Need HTTP::Tiny 0.055 or later.
+            - name: Install cpanm and multiple modules
+              run: |
+                curl -L https://cpanmin.us | perl - App::cpanminus
+                cpanm --notest IO::Socket::SSL LWP::Protocol::https App::Cpan HTTP::Tiny ExtUtils::MakeMaker Test::Manifest Test::More
+# Install the dependencies, again not testing them. This installs the
+# module in the current directory, so we end up installing the module,
+# but that's not a big deal.
+            - name: Install dependencies
+              run: |
+                cpanm --notest --installdeps --with-suggests --with-recommends .
+            - name: Show cpanm failures
+              if: ${{ failure() }}
+              run: |
+                cat /github/home/.cpanm/work/*/build.log
+            - name: Run tests
+              run: |
+                perl Makefile.PL
+                make test
+# Run author tests, but only if there's an xt/ directory
+            - name: Author tests
+              if: hashFiles('xt') != ''
+              run: |
+                cpanm --notest Test::CPAN::Changes
+                prove -r -b xt
+# Running tests in parallel should be faster, but it's also more
+# tricky in cases where different tests share a feature, such as a
+# file they want to write to. Parallel tests can stomp on each other.
+# Test in parallel to catch that, because other people will test your
+# stuff in parallel.
+            - name: Run tests in parallel
+              run: |
+                perl Makefile.PL
+                HARNESS_OPTIONS=j10 make test
+# The disttest target creates the distribution, unwraps it, changes
+# into the dist dir, then runs the tests there. That checks that
+# everything that should be in the dist is in the dist. If you forget
+# to update MANIFEST with new modules, data files, and so on, you
+# should notice the error.
+            - name: Run distribution tests
+              run: |
+                perl Makefile.PL
+                make disttest
+                make clean
+# And, coverage reports, but only under 5.12 and later since modern
+# Devel::Cover instances don't work with earlier versions as of
+# Devel::Cover 1.39
+            - name: Run coverage tests
+              if: env.PERL_VERSION != 'v5.8' && env.PERL_VERSION != 'v5.10'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                cpanm --notest Devel::Cover Devel::Cover::Report::Coveralls
+                perl Makefile.PL
+                cover -test -report coveralls

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -98,7 +98,7 @@ jobs:
             - name: Install cpanm and multiple modules
               run: |
                 curl -L https://cpanmin.us | perl - App::cpanminus
-                cpanm --notest IO::Socket::SSL LWP::Protocol::https App::Cpan HTTP::Tiny ExtUtils::MakeMaker Test::Manifest Test::More
+                cpanm --notest IO::Socket::SSL App::Cpan HTTP::Tiny ExtUtils::MakeMaker Test::Manifest Test::More
 # Install the dependencies, again not testing them. This installs the
 # module in the current directory, so we end up installing the module,
 # but that's not a big deal.

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -62,6 +62,7 @@ jobs:
           - "5.14"
           - "5.12"
           - "5.10"
+          - "5.8"
 
     container:
       image: perl:${{ matrix.perl-version }}

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,5 @@
 package main;
 
-use 5.010;
-
 use strict;
 
 use ExtUtils::MakeMaker 6.46;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,6 @@ my %parms = (
     ABSTRACT         => 'Data tables useful in parsing HTML',
     VERSION_FROM     => 'lib/HTML/Tagset.pm',
     LICENSE          => 'artistic_2',
-    MIN_PERL_VERSION => 5.010001,
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => '6.46',
     },

--- a/lib/HTML/Tagset.pm
+++ b/lib/HTML/Tagset.pm
@@ -12,7 +12,7 @@ Version 3.24
 
 =cut
 
-our $VERSION = '3.24';
+our $VERSION = '3.24_01';
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
I don't see any v5.10 features here, and the tests pass under v5.8. This module is a pre-requisite to other modules that have minimum versions of v5.8, which means this module moving to v5.10 inadvertently breaks modules that should work with v5.8.

Also, along the way GitHub has screwed up workflows such that we can't use the old perl images: Perl/docker-per#161 . I threw in my basic Ubuntu workflow file from briandfoy/github_workflows, but you don't have to use that. It does have one change to get around installing this module from CPAN on v5.8.

The Changes files noted a lack of infrastructure to test on v5.8, but GitHub workflows and CPAN Testers will handle that. And, there are v5.8 docker images too.